### PR TITLE
Numbers with space characters fail to dial. Support "tel:" url. Don't rely on model name.

### DIFF
--- a/PhoneDialer.m
+++ b/PhoneDialer.m
@@ -1,31 +1,37 @@
 //
 //  PhoneDialer.m
 //
-//  Created by Justin McNally on 11/17/11.
-//  Copyright (c) 2011 Kohactive. All rights reserved.
+//  Revised by Trevor Cox 01/06/12
+//   Copyright (c) 2012 Appazur Solutions Inc.
+//
+//  Original created by Justin McNally on 11/17/11.
+//   Copyright (c) 2011 Kohactive. All rights reserved.
 //
 
 #import "PhoneDialer.h"
 
-
-
 @implementation PhoneDialer
 
-
-
+// 'number' param may be either an unescaped phone number or a tel: url
 - (void) dialPhone:(NSMutableArray *)arguments withDict:(NSMutableDictionary *)options {
+    NSString* url;
+    NSString* number = [options valueForKey:@"number"];
+    if([number hasPrefix:@"tel:"]) {
+        url = number;
+    }
+    else {
+        // escape characters such as spaces that may not be accepted by openURL
+        url = [NSString stringWithFormat:@"tel:%@",
+            [number stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+    }
     
-    NSString* ph = [options valueForKey:@"number"];
-    
-    UIDevice *device = [UIDevice currentDevice];
-    if ([[device model] isEqualToString:@"iPhone"] ) {
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[NSString stringWithFormat:@"tel:%@", ph]]];
-    } else {
-        UIAlertView *Notpermitted=[[UIAlertView alloc] initWithTitle:@"Alert" message:@"Your device doesn't support this feature." delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil];
+    // openURL is expected to fail on devices that do not have the Phone app, such as simulators, iPad, iPod touch
+    if(![[UIApplication sharedApplication] openURL:[NSURL URLWithString:url]]) {
+        NSLog(@"openURL failed, %@, %@", [[UIDevice currentDevice] model], url);
+        UIAlertView *Notpermitted=[[UIAlertView alloc] initWithTitle:@"Phone" message:@"Your device doesn't support this feature." delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil];
         [Notpermitted show];
         [Notpermitted release];
     }
-    
 }
 
 @end


### PR DESCRIPTION
Fix: Numbers with space characters fail to dial.

Fix: Don't assume openURL will always succeed if model='iPhone' and always fail otherwise.
 (e.g. future 'iPhone Simulator' may have a Phone app, or VoIP tel: support may be added to iPad.)

Add support for "tel:" url as well as raw phone number as param.
